### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4",
         "php-http/httplug": "^1.0.0-alpha2@dev",
-        "php-http/message-factory": "^0.4@dev"
+        "php-http/message-factory": "^0.3@dev"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.2",


### PR DESCRIPTION
Installation fails because 0.4 does not exist. Changing to "0.3 and above" fixes things, as it installs 0.3 while 1.0 is still in pre-release status. Alternatively, we could set minimum stability to dev, and then require "^1.0" of message-factory, but seeing as that's not ready yet, I think going lower is better for now, so at least current implementations will continue to work.
